### PR TITLE
Fixe the compilation errors in pods project when using `use_frameworks!` in the pod file

### DIFF
--- a/react-native-webrtc.podspec
+++ b/react-native-webrtc.podspec
@@ -20,4 +20,5 @@ Pod::Spec.new do |s|
   s.framework           = 'AudioToolbox','AVFoundation', 'CoreAudio', 'CoreGraphics', 'CoreVideo', 'GLKit', 'VideoToolbox'
   s.ios.vendored_frameworks = 'ios/WebRTC.framework'
   s.xcconfig            = { 'OTHER_LDFLAGS' => '-framework WebRTC' }
+  s.dependency 			'React'
 end


### PR DESCRIPTION
Fix the compilation errors in resulting pods project (couldn’t find React headers) when `using use_frameworks!` in the referencing pod file

@chrmod